### PR TITLE
Add support for LspReference*

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -216,7 +216,10 @@ hl.plugins.lsp = {
     LspDiagnosticsUnderlineError = {underline = true, sp = c.red},
     LspDiagnosticsUnderlineHint = {underline = true, sp = c.purple},
     LspDiagnosticsUnderlineInformation = {underline = true, sp = c.blue},
-    LspDiagnosticsUnderlineWarning = {underline = true, sp = c.yellow}
+    LspDiagnosticsUnderlineWarning = {underline = true, sp = c.yellow},
+    LspReferenceText = {underline = true },
+    LspReferenceWrite = {underline = true },
+    LspReferenceRead = {underline = true }
 }
 
 hl.plugins.whichkey = {


### PR DESCRIPTION
Add LspReferenceText, LspReferenceWrite and LspReferenceRead highlight
groups. These are required to use the function
`vim.lsp.buf.document_highlight()`.

I’m not sure only underlining is the best option, as it is associated with errors as well.

![screen_2021-06-17T23:05:00,917340423+01:00](https://user-images.githubusercontent.com/7347374/122478361-2a490b80-cfc1-11eb-8621-852958699c96.png)

 I’ve considered using `{fg = c.bg0, bg = c.orange},` as with `IncSearch`, but it is quite intrusive. You have put together this great colorscheme, so I’m sure you’ll pick something good for this highlight group!