### PR TITLE
Add hop.nvim plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A Dark Theme for neovim >= 0.5 based on [Atom One Dark Theme](https://github.com
   + [GitSigns](https://github.com/lewis6991/gitsigns.nvim)
   + [VimFugitive](https://github.com/tpope/vim-fugitive)
   + [DiffView](https://github.com/sindrets/diffview.nvim)
+  + [Hop](https://github.com/phaazon/hop.nvim)
 
 ## Styles
 ### Dark

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -235,6 +235,13 @@ hl.plugins.gitgutter = {
     GitGutterDelete = {fg = c.red},
 }
 
+hl.plugins.hop = {
+    HopNextKey = {fg = c.bg0, bg = c.orange},
+    HopNextKey1 = {fg = c.bg0, bg = c.orange},
+    HopNextKey2 = {fg = c.bg0, bg = c.bg_yellow},
+    HopUnmatched = {fg = c.fg, bg = c.bg1},
+}
+
 hl.plugins.diffview = {
     DiffviewFilePanelTitle = {fg = c.blue, bold = true},
     DiffviewFilePanelCounter = {fg = c.purple, bold = true},


### PR DESCRIPTION
 Hop.nvim is a bit like EasyMotion, but written in lua.

I realize it may not be desirable to add every possible plugin. Hop.nvim seems to require very few highlight group definition though, so it may be worth having by default.

This is what an “active jump” looks like:
![image](https://user-images.githubusercontent.com/7347374/122672675-64323180-d1bc-11eb-8896-fb08fa3b0765.png)
