### PR TITLE
Enable/Disable mapping

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -2,7 +2,10 @@ lua << EOF
 for k in pairs(package.loaded) do
     if k:match(".*onedark.*") then package.loaded[k] = nil end
 end
-vim.api.nvim_set_keymap('n', '<leader>cs', [[<Cmd>lua require('onedark').toggle()<CR>]], { noremap = true, silent = true })
+local disable = vim.g.disable_toggle_style or 0
+if disable == 0 then
+    vim.api.nvim_set_keymap('n', '<leader>cs', [[<Cmd>lua require('onedark').toggle()<CR>]], { noremap = true, silent = true })
+end
 require('onedark').setup()
 EOF
 


### PR DESCRIPTION
I have a specific style I want to use, and I want to disable key mapping.
Disable it by setting the environment variable as follows.
```
vim.g.disable_toggle_style = 1
vim.g.onedark_style = "deep"
require"onedark".setup()
```