### PR TITLE
feat: allow disable terminal colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,17 @@ vim.g.onedark_disable_toggle_style = true -- By default it is false
 require('onedark').setup()
 ```
 
+### To disable terminal colors
+```vim
+let g:onedark_disable_terminal_colors = 1 " By default it is 0
+colorscheme onedark
+```
+
+```lua
+vim.g.onedark_disable_terminal_colors = true -- By default it is false
+require('onedark').setup()
+```
+
 ### To use underline instead of undercurl for diagnostics
 ```vim
 let g:onedark_diagnostics_undercurl = 0 " By default it is 1

--- a/lua/onedark/config.lua
+++ b/lua/onedark/config.lua
@@ -9,6 +9,7 @@ local config = {
     italic_comment = get("italic_comment", true),
     diagnostics_undercurl = get("diagnostics_undercurl", true),
     darker_diagnostics = get("darker_diagnostics", true),
+    disable_terminal_colors = get("disable_terminal_colors", false)
 }
 
 return config

--- a/lua/onedark/terminal.lua
+++ b/lua/onedark/terminal.lua
@@ -1,7 +1,9 @@
 local M = {}
+local cfg = require('onedark.config')
 local c = require 'onedark.colors'
 
 function M.setup()
+    if cfg.disable_terminal_colors then return end
     vim.g.terminal_color_0 = c.grey
     vim.g.terminal_color_1 = c.red
     vim.g.terminal_color_2 = c.green


### PR DESCRIPTION
The colorscheme is not playing very nice with my terminal scheme, so I'd prefer to have it disabled on neovim.

This puts the terminal colors change behind a flag so users can disable if they want.

Hope this pr is in a good shape for this repo.