### PR TITLE
Add highlight group for float windows

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -61,7 +61,7 @@ hl.common = {
     IncSearch = {fg = c.bg0, bg = c.orange},
     Search = {fg = c.bg0, bg = c.bg_yellow},
     Substitute = {fg = c.bg0, bg = c.green},
-    MatchParen = {fg = c.none, bg = c.grey},
+    MatchParen = {fg = c.bg0, bg = c.bg_blue},
     NonText = {fg = c.grey},
     Whitespace = {fg = c.grey},
     SpecialKey = {fg = c.grey},

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -90,8 +90,9 @@ hl.common = {
     debugPC = {fg = c.bg0, bg = c.green},
     debugBreakpoint = {fg = c.bg0, bg = c.red},
     ToolbarButton = {fg = c.bg0, bg = c.bg_blue},
-    FloatBorder = {fg = c.fg, bg = c.bg1},
-    NormalFloat = {fg = c.fg, bg = c.bg1}
+    FloatBorder = {fg = c.gray, bg = c.bg1},
+    NormalFloat = {fg = c.fg, bg = c.bg1},
+    VertSplit = {fg = c.bg3}
 }
 
 hl.syntax = {

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -122,7 +122,7 @@ hl.syntax = {
     Special = colors.Red,
     SpecialChar = colors.Red,
     Function = {fg = c.blue, fmt = cfg.code_style.functions},
-    Operator = colors.Fg,
+    Operator = colors.Purple,
     Title = colors.Cyan,
     Tag = colors.Green,
     Delimiter = colors.LightGrey,

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -89,7 +89,9 @@ hl.common = {
     Debug = {fg = c.yellow},
     debugPC = {fg = c.bg0, bg = c.green},
     debugBreakpoint = {fg = c.bg0, bg = c.red},
-    ToolbarButton = {fg = c.bg0, bg = c.bg_blue}
+    ToolbarButton = {fg = c.bg0, bg = c.bg_blue},
+    FloatBorder = {fg = c.fg, bg = c.bg1},
+    NormalFloat = {fg = c.fg, bg = c.bg1}
 }
 
 hl.syntax = {


### PR DESCRIPTION
The current theme does not have groups for float windows, and makes the borders of float windows hard to distinguish since it defaults to some highlight group whose foreground color is dark gray.

This PR fixes this problem by adding two specific groups for float windows, namely `NormalFloat` and `FloatBorder`, and uses proper color from the palette.