### PR TITLE
Lsp Diagnostic colors configurable from user setup

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -192,10 +192,10 @@ hl.treesitter = {
     TSVariableBuiltin = {fg = c.red, fmt = cfg.code_style.variables},
 }
 
-local diagnostics_error_color = cfg.diagnostics.darker and c.dark_red or c.red
-local diagnostics_hint_color = cfg.diagnostics.darker and c.dark_purple or c.purple
-local diagnostics_warn_color = cfg.diagnostics.darker and c.dark_yellow or c.yellow
-local diagnostics_info_color = cfg.diagnostics.darker and c.dark_cyan or c.cyan
+local diagnostics_error_color = cfg.diagnostics.error_color or cfg.diagnostics.darker and c.dark_red or c.red
+local diagnostics_hint_color = cfg.diagnostics.hint_color or cfg.diagnostics.darker and c.dark_purple or c.purple
+local diagnostics_warn_color = cfg.diagnostics.warn_color or cfg.diagnostics.darker and c.dark_yellow or c.yellow
+local diagnostics_info_color = cfg.diagnostics.info_color or cfg.diagnostics.darker and c.dark_cyan or c.cyan
 hl.plugins.lsp = {
     LspCxxHlGroupEnumConstant = colors.Orange,
     LspCxxHlGroupMemberVariable = colors.Orange,
@@ -203,10 +203,10 @@ hl.plugins.lsp = {
     LspCxxHlSkippedRegion = colors.Grey,
     LspCxxHlSkippedRegionBeginEnd = colors.Red,
 
-    DiagnosticError = {fg = c.red},
-    DiagnosticHint = {fg = c.purple},
-    DiagnosticInfo = {fg = c.cyan},
-    DiagnosticWarn = {fg = c.yellow},
+    DiagnosticError = {fg = diagnostics_error_color},
+    DiagnosticHint = {fg = diagnostics_hint_color},
+    DiagnosticInfo = {fg = diagnostics_info_color},
+    DiagnosticWarn = {fg = diagnostics_warn_color},
 
     DiagnosticVirtualTextError = { bg = cfg.diagnostics.background and util.darken(diagnostics_error_color, 0.1, c.bg0) or c.none,
                                    fg = diagnostics_error_color },


### PR DESCRIPTION
@navarasu I love your work on this theme!

I'd like you to merge in this Pull Request to allow users to configure the Lsp Diagnostic colors from their .vimrc or lua init files.

For example, in my .vimrc I want to do this with your theme: 
```
let g:onedark_config = {
  ...
  \ 'diagnostics': {
  ...
   \ 'hint_color': "#56b6c2",
\ },
```

To get that nice cyan to show up for me as hints. Other users may want to configure their error, hint, warn, or info colors as well.

This pull request allows that user customization with your theme!