### PR TITLE
Add LSP Code Lens highlights

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -225,6 +225,9 @@ hl.plugins.lsp = {
     LspReferenceText = { bg = c.bg2 },
     LspReferenceWrite = { bg = c.bg2 },
     LspReferenceRead = { bg = c.bg2 },
+
+    LspCodeLens = { fg = c.grey, fmt = cfg.code_style.comments },
+    LspCodeLensSeparator = { fg = c.grey },
 }
 
 hl.plugins.lsp.LspDiagnosticsDefaultError = hl.plugins.lsp.DiagnosticError


### PR DESCRIPTION
- LspCodeLens has the same style as Comment
- LspCodeLensSeparator only has the Comment's fg