### PR TITLE
Fix diff coloring in light mode

### DIFF
--- a/lua/onedark/palette.lua
+++ b/lua/onedark/palette.lua
@@ -190,9 +190,9 @@ return {
 		dark_red = "#833b3b",
 		dark_yellow = "#7c5c20",
 		dark_purple = "#79428a",
-		diff_add = "#282b26",
-		diff_delete = "#2a2626",
-		diff_change = "#1a2a37",
-		diff_text = "#2c485f",
+		diff_add = "#e2fbe4",
+		diff_delete = "#fce2e5",
+		diff_change = "#e2ecfb",
+		diff_text = "#cad3e0",
 	},
 }


### PR DESCRIPTION
This PR fixes issue #61.

The colors for added and deleted regions are taken from Atom using an eyedropper tool.
Since Atom doesn't have a color for changed regions, I've used a tetrad color of the color for added regions.

Here is a screenshot:
![image](https://user-images.githubusercontent.com/29507110/175455293-b606832b-3b6a-4d34-b262-f98f8f7c5d42.png)
