### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ require('lualine').setup {
   + [VimFugitive](https://github.com/tpope/vim-fugitive)
   + [DiffView](https://github.com/sindrets/diffview.nvim)
   + [Hop](https://github.com/phaazon/hop.nvim)
+  + [Mini](https://github.com/echasnovski/mini.nvim)
 
 ## Reference
 * [tokyodark.nvim](https://github.com/tiagovla/tokyodark.nvim)

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -384,6 +384,58 @@ hl.plugins.ts_rainbow = {
     rainbowcol7 = colors.Red
 }
 
+hl.plugins.mini = {
+    MiniCompletionActiveParameter = { fmt = "underline" },
+
+    MiniCursorword = { fmt = "underline" },
+    MiniCursorwordCurrent = { fmt = "underline" },
+
+    MiniIndentscopeSymbol = { fg = c.light_grey },
+    MiniIndentscopePrefix = { fmt = "nocombine" }, -- Make it invisible
+
+    MiniJump = { fg = c.purple, fmt = "underline", sp = c.purple },
+
+    MiniJump2dSpot = { fg = c.red, fmt = "bold,nocombine" },
+
+    MiniStarterCurrent = { fmt = "nocombine" },
+    MiniStarterFooter = { fg = c.dark_red, fmt = "italic" },
+    MiniStarterHeader = colors.Yellow,
+    MiniStarterInactive = { fg = c.grey, fmt = cfg.code_style.comments },
+    MiniStarterItem = { fg = c.fg, bg = cfg.transparent and c.none or c.bg0 },
+    MiniStarterItemBullet = { fg = c.grey },
+    MiniStarterItemPrefix = { fg = c.yellow },
+    MiniStarterSection = colors.LightGrey,
+    MiniStarterQuery = { fg = c.cyan },
+
+    MiniStatuslineDevinfo = { fg = c.fg, bg = c.bg2 },
+    MiniStatuslineFileinfo = { fg = c.fg, bg = c.bg2 },
+    MiniStatuslineFilename = { fg = c.grey, bg = c.bg1 },
+    MiniStatuslineInactive = { fg = c.grey, bg = c.bg0 },
+    MiniStatuslineModeCommand = { fg = c.bg0, bg = c.yellow, fmt = "bold" },
+    MiniStatuslineModeInsert = { fg = c.bg0, bg = c.blue, fmt = "bold" },
+    MiniStatuslineModeNormal = { fg = c.bg0, bg = c.green, fmt = "bold" },
+    MiniStatuslineModeOther = { fg = c.bg0, bg = c.cyen, fmt = "bold" },
+    MiniStatuslineModeReplace = { fg = c.bg0, bg = c.red, fmt = "bold" },
+    MiniStatuslineModeVisual = { fg = c.bg0, bg = c.purple, fmt = "bold" },
+
+    MiniSurround = { fg = c.bg0, bg = c.orange },
+
+    MiniTablineCurrent = { fmt = "bold" },
+    MiniTablineFill = { fg = c.grey, bg = c.bg1 },
+    MiniTablineHidden = { fg = c.fg, bg = c.bg1 },
+    MiniTablineModifiedCurrent = { fg = c.orange, fmt = "bold,italic" },
+    MiniTablineModifiedHidden = { fg = c.light_grey, bg = c.bg1, fmt = "italic" },
+    MiniTablineModifiedVisible = { fg = c.yellow, bg = c.bg0, fmt = "italic" },
+    MiniTablineTabpagesection = { fg = c.bg0, bg = c.bg_yellow },
+    MiniTablineVisible = { fg = c.light_grey, bg = c.bg0 },
+
+    MiniTestEmphasis = { fmt = "bold" },
+    MiniTestFail = { fg = c.red, fmt = "bold" },
+    MiniTestPass = { fg = c.green, fmt = "bold" },
+
+    MiniTrailspace = { bg = c.red },
+}
+
 hl.langs.c = {
     cInclude = colors.Blue,
     cStorageClass = colors.Purple,


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from highlight groups to which 'mini.nvim' makes links by default or from analogous plugins.

Differences from default linked groups:
- 'mini.jump2d' is based on 'Hop'. Added `nocombine` for it to always be consistent (not become italic on italic text).
- 'mini.starter' is based on 'dashboard.lua' and personal choices:
    - `MiniStarterItemBullet` is as border.
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
- 'mini.statusline' is based on 'lualine/themes/onedark.lua' and personal choices:
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` have slightly different background.
    - `MiniStatuslineModeOther` is chosen from terminal mode.
- 'mini.tabline' is based on 'Barbar':
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177955103-e99bfd6b-4131-466a-a398-9baa81ce4e41.mp4

After:

https://user-images.githubusercontent.com/24854248/177955157-1632cdd8-ab1f-47c1-9a75-c7c42446a420.mp4
