### PR TITLE
Add option to disable the toggle keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ require('onedark').setup  {
     ending_tildes = false, -- Show the end-of-buffer tildes. By default they are hidden
     cmp_itemkind_reverse = false, -- reverse item kind highlights in cmp menu
     -- toggle theme style ---
+    toggle_enabled = true -- Enable or disable the toggle keybinding
     toggle_style_key = '<leader>ts', -- Default keybinding to toggle
     toggle_style_list = {'dark', 'darker', 'cool', 'deep', 'warm', 'warmer', 'light'}, -- List of styles to toggle between
 

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -44,6 +44,7 @@ end
 local default_config = {
     -- Main options --
     style = 'dark',    -- choose between 'dark', 'darker', 'cool', 'deep', 'warm', 'warmer' and 'light'
+    toggle_enabled = true,
     toggle_style_key = '<leader>ts',
     toggle_style_list = M.styles_list,
     transparent = false,     -- don't set background
@@ -88,7 +89,9 @@ function M.setup(opts)
             M.set_options('toggle_style_list', opts.toggle_style_list)
         end
     end
-    vim.api.nvim_set_keymap('n', vim.g.onedark_config.toggle_style_key, '<cmd>lua require("onedark").toggle()<cr>', { noremap = true, silent = true })
+    if vim.g.onedark_config.toggle_enabled then
+      vim.api.nvim_set_keymap('n', vim.g.onedark_config.toggle_style_key, '<cmd>lua require("onedark").toggle()<cr>', { noremap = true, silent = true })
+    end
 end
 
 function M.load()


### PR DESCRIPTION
Introduce a new configuration option `toggle_enabled` to enable/disable the the toggle keybinding. Default value is `true` (enabled), so no breaking changes.