### PR TITLE
Disable `toggle_style_key` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   * 8 theme styles (One Dark + 5 variants) and (One Light + 1 variant)
   * Supporting multiple plugins with hand picked proper colors
   * Customize `Colors`, `Highlights` and `Code style` of the theme as you like (Refer [Customization](#customization))
-  * Toggle the theme style without exiting Neovim using shortcut `<leader>ts` (Refer [Default Config](#default-configuration))
+  * Toggle the theme style without exiting Neovim using `toggle_style_key` (Refer [Config](#default-configuration))
 
 ## Themes
 <p float="left">
@@ -93,8 +93,9 @@ require('onedark').setup  {
     term_colors = true, -- Change terminal color as per the selected theme style
     ending_tildes = false, -- Show the end-of-buffer tildes. By default they are hidden
     cmp_itemkind_reverse = false, -- reverse item kind highlights in cmp menu
+
     -- toggle theme style ---
-    toggle_style_key = '<leader>ts', -- Default keybinding to toggle
+    toggle_style_key = nil, -- keybind to toggle theme style. Leave it nil to disable it, or set it to a string, for example "<leader>ts"
     toggle_style_list = {'dark', 'darker', 'cool', 'deep', 'warm', 'warmer', 'light'}, -- List of styles to toggle between
 
     -- Change code style ---

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -44,7 +44,7 @@ end
 local default_config = {
     -- Main options --
     style = 'dark',    -- choose between 'dark', 'darker', 'cool', 'deep', 'warm', 'warmer' and 'light'
-    toggle_style_key = '<leader>ts',
+    toggle_style_key = nil,
     toggle_style_list = M.styles_list,
     transparent = false,     -- don't set background
     term_colors = true,      -- if true enable the terminal
@@ -88,7 +88,7 @@ function M.setup(opts)
             M.set_options('toggle_style_list', opts.toggle_style_list)
         end
     end
-    if vim.g.onedark_config.toggle_style_key ~= '' then
+    if vim.g.onedark_config.toggle_style_key then
       vim.api.nvim_set_keymap('n', vim.g.onedark_config.toggle_style_key, '<cmd>lua require("onedark").toggle()<cr>', { noremap = true, silent = true })
     end
 end


### PR DESCRIPTION
Fix #89 
As @itaranto said, it should be disabled by default. See https://github.com/navarasu/onedark.nvim/issues/89#issuecomment-1195730099

Also deprecate #91, because now `toggle_style_key` is disabled with `nil` value and not empty string