### PR TITLE
Specific lualine transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ require('onedark').setup  {
         variables = 'none'
     },
 
+    -- Lualine options --
+    lualine = {
+        transparent = false, -- lualine center bar transparency
+    },
+
     -- Custom Highlights --
     colors = {}, -- Override default colors
     highlights = {}, -- Override highlight groups

--- a/lua/lualine/themes/onedark.lua
+++ b/lua/lualine/themes/onedark.lua
@@ -16,12 +16,12 @@ local one_dark = {
     inactive = {
         a = {fg = colors.gray, bg = colors.bg, gui = 'bold'},
         b = {fg = colors.gray, bg = colors.bg},
-        c = {fg = colors.gray, bg = cfg.transparent and c.none or c.bg1},
+        c = {fg = colors.gray, bg = cfg.lualine.transparent and c.none or c.bg1},
     },
     normal = {
         a = {fg = colors.bg, bg = colors.green, gui = 'bold'},
         b = {fg = colors.fg, bg = c.bg3},
-        c = {fg = colors.fg, bg = cfg.transparent and c.none or c.bg1},
+        c = {fg = colors.gray, bg = cfg.lualine.transparent and c.none or c.bg1},
     },
     visual = {a = {fg = colors.bg, bg = colors.purple, gui = 'bold'}},
     replace = {a = {fg = colors.bg, bg = colors.red, gui = 'bold'}},

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -60,6 +60,11 @@ local default_config = {
         variables = 'none'
     },
 
+    -- Lualine options --
+    lualine = {
+        transparent = false, -- center bar (c) transparency
+    },
+
     -- Custom Highlights --
     colors = {}, -- Override default colors
     highlights = {}, -- Override highlight groups


### PR DESCRIPTION
Added transparency customization for Lualine separate from global transparency option. This new 'lualine' config table might be extended for future lualine-specific customizations.

I just wanted my lualine to not be transparent when I set the plugin transparency to true :)