### PR TITLE
changed rainbowcol1 to lightgrey

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -484,7 +484,7 @@ hl.plugins.navic = {
 }
 
 hl.plugins.ts_rainbow = {
-    rainbowcol1 = colors.Grey,
+    rainbowcol1 = colors.LightGrey,
     rainbowcol2 = colors.Yellow,
     rainbowcol3 = colors.Blue,
     rainbowcol4 = colors.Orange,


### PR DESCRIPTION
Fixes #104 
Fixes #127 

Although it is possible for user to change the color for `rainbowcol1` as mentioned in #127, I still believe that this is an better default as it:
- does not look significantly worse.
- does not get covered up by MatchParen's background.