### PR TITLE
Adding semantic token support

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -197,6 +197,30 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
         ["@variable"] = {fg = c.fg, fmt = cfg.code_style.variables},
         ["@variable.builtin"] = {fg = c.red, fmt = cfg.code_style.variables},
     }
+    if vim.api.nvim_call_function("has", { "nvim-0.9" }) == 1 then
+        hl.lsp = {
+            ["@lsp.type.comment"] = hl.treesitter[ "@comment"],
+            ["@lsp.type.enum"] = hl.treesitter["@type"],
+            ["@lsp.type.enumMember"] = hl.treesitter["@constant.builtin"],
+            ["@lsp.type.interface"] = hl.treesitter["@variable.builtin"],
+            ["@lsp.type.keyword"] = hl.treesitter["@keyword"],
+            ["@lsp.type.namespace"] = hl.treesitter["@namespace"],
+            ["@lsp.type.parameter"] = hl.treesitter["@parameter"],
+            ["@lsp.type.property"] = hl.treesitter["@property"],
+            ["@lsp.type.variable"] = hl.treesitter["@variable"],
+            ["@lsp.type.macro"] = hl.treesitter["@function.macro"],
+            ["@lsp.type.method"] = hl.treesitter["@method"],
+            ["@lsp.type.number"] = hl.treesitter["@number"],
+            ["@lsp.type.generic"] = hl.treesitter["@text"],
+            ["@lsp.type.builtinType"] = hl.treesitter["@type.builtin"],
+            ["@lsp.typemod.method.defaultLibrary"] = hl.treesitter["@function"],
+            ["@lsp.typemod.function.defaultLibrary"] = hl.treesitter["@function"],
+            ["@lsp.typemod.operator.injected"] = hl.treesitter["@operator"],
+            ["@lsp.typemod.string.injected"] = hl.treesitter["@string"],
+            ["@lsp.typemod.variable.defaultLibrary"] = hl.treesitter["@variable.builtin"],
+            ["@lsp.typemod.variable.injected"] = hl.treesitter["@variable"],
+        }
+    end
 else
     hl.treesitter = {
         TSAnnotation = colors.Fg,
@@ -716,6 +740,9 @@ function M.setup()
     vim_highlights(hl.common)
     vim_highlights(hl.syntax)
     vim_highlights(hl.treesitter)
+    if hl.lsp then
+        vim_highlights(hl.lsp)
+    end
     for _, group in pairs(hl.langs) do vim_highlights(group) end
     for _, group in pairs(hl.plugins) do vim_highlights(group) end
 

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -160,7 +160,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
         ["@none"] = colors.Fg,
         ["@number"] = colors.Orange,
         ["@operator"] = colors.Fg,
-        ["@parameter"] = colors.Orange,
+        ["@parameter"] = colors.Red,
         ["@parameter.reference"] = colors.Fg,
         ["@property"] = colors.Cyan,
         ["@punctuation.delimiter"] = colors.LightGrey,

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -202,7 +202,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
             ["@lsp.type.comment"] = hl.treesitter[ "@comment"],
             ["@lsp.type.enum"] = hl.treesitter["@type"],
             ["@lsp.type.enumMember"] = hl.treesitter["@constant.builtin"],
-            ["@lsp.type.interface"] = hl.treesitter["@variable.builtin"],
+            ["@lsp.type.interface"] = hl.treesitter["@type"],
             ["@lsp.type.keyword"] = hl.treesitter["@keyword"],
             ["@lsp.type.namespace"] = hl.treesitter["@namespace"],
             ["@lsp.type.parameter"] = hl.treesitter["@parameter"],

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -160,7 +160,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
         ["@none"] = colors.Fg,
         ["@number"] = colors.Orange,
         ["@operator"] = colors.Fg,
-        ["@parameter"] = colors.Red,
+        ["@parameter"] = colors.Orange,
         ["@parameter.reference"] = colors.Fg,
         ["@property"] = colors.Cyan,
         ["@punctuation.delimiter"] = colors.LightGrey,

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -203,6 +203,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
             ["@lsp.type.enum"] = hl.treesitter["@type"],
             ["@lsp.type.enumMember"] = hl.treesitter["@constant.builtin"],
             ["@lsp.type.interface"] = hl.treesitter["@type"],
+            ["@lsp.type.typeParameter"] = hl.treesitter["@type"],
             ["@lsp.type.keyword"] = hl.treesitter["@keyword"],
             ["@lsp.type.namespace"] = hl.treesitter["@namespace"],
             ["@lsp.type.parameter"] = hl.treesitter["@parameter"],


### PR DESCRIPTION
Fixes #156.
Fixes #140.

I wouldn't say I've made semantic tokens look good on every languages out there, but I do think this is good enough to be merged for now and be slowly improved later on. I do also think it is a significant improvement over how semantic tokens currently looks with nvim 0.9.

Here's how rust looks with treesitter only highlighting:
![without semantic token](https://user-images.githubusercontent.com/38484873/232219542-45f7aa87-9fdc-409b-ba39-6af2a60f3115.png)

Here's how the same piece of rust looks with semantic token but before this PR, as you can see, it's quite unsightly:
![before this PR](https://user-images.githubusercontent.com/38484873/232219734-48b76728-71e8-4706-b118-64d869f20034.png)

Here's how the same piece of rust looks with semantic token after this PR, notice how the doc test got syntax highlighting as it has been labeled by rust-analyzer:
![with semantic token](https://user-images.githubusercontent.com/38484873/232219896-4b019800-ae07-4878-a78e-fa3505fcaa63.png)

BTW, I don't think parameters should be red but I can't think of any better color other than white so I'm opened to suggestions.