### PR TITLE
Add nvim-ts-rainbow2 support

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -518,6 +518,16 @@ hl.plugins.ts_rainbow = {
     rainbowcol7 = colors.Red
 }
 
+hl.plugins.ts_rainbow2 = {
+    TSRainbowRed = colors.Red,
+    TSRainbowYellow = colors.Yellow,
+    TSRainbowBlue = colors.Blue,
+    TSRainbowOrange = colors.Orange,
+    TSRainbowGreen = colors.Green,
+    TSRainbowViolet = colors.Purple,
+    TSRainbowCyan = colors.Cyan,
+}
+
 hl.plugins.indent_blankline = {
     IndentBlanklineIndent1 = colors.Blue,
     IndentBlanklineIndent2 = colors.Green,


### PR DESCRIPTION
This PR adds highlight groups of nvim-ts-rainbow2 since it is the active fork of nvim-ts-rainbow.
I didn't remove the old highlight groups since some people might be still using it and it doesn't bother anyone.