### PR TITLE
`@lsp.typemod.variable.static` set to `@constant`

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -220,6 +220,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
             ["@lsp.typemod.string.injected"] = hl.treesitter["@string"],
             ["@lsp.typemod.variable.defaultLibrary"] = hl.treesitter["@variable.builtin"],
             ["@lsp.typemod.variable.injected"] = hl.treesitter["@variable"],
+            ["@lsp.typemod.variable.static"] = hl.treesitter["@constant"],
         }
     end
 else


### PR DESCRIPTION
Constants in Rust (and probably other languages) started just being white with semantic highlighting enabled. With this PR, they are highlighted as constants, as they are without semantic highlighting.