### PR TITLE
add explicit style for `@preproc`

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -162,6 +162,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
         ["@operator"] = colors.Fg,
         ["@parameter"] = colors.Red,
         ["@parameter.reference"] = colors.Fg,
+        ["@preproc"] = colors.Purple,
         ["@property"] = colors.Cyan,
         ["@punctuation.delimiter"] = colors.LightGrey,
         ["@punctuation.bracket"] = colors.LightGrey,


### PR DESCRIPTION
This PR adds an explicit style for tree-sitter's `@preproc`, although Neovim already automatically uses the style defined for `Preproc`. I just think it's cleaner to directly specify it.