### PR TITLE
fix: correctly highlight indent blankline context using fmt

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -537,11 +537,10 @@ hl.plugins.indent_blankline = {
     IndentBlanklineIndent4 = colors.LightGrey,
     IndentBlanklineIndent5 = colors.Purple,
     IndentBlanklineIndent6 = colors.Red,
-    IndentBlanklineChar = { fg = c.bg1, gui = "nocombine" },
-    IndentBlanklineContext = { fg = c.orange, bg = c.grey, bold = true },
-    IndentBlanklineContextChar = { fg = c.grey, gui = "nocombine" },
-    IndentBlanklineContextStart = { sp = c.grey, gui = "underline" },
-    IndentBlanklineContextSpaceChar = { gui = "nocombine" },
+    IndentBlanklineChar = { fg = c.bg1, fmt = "nocombine" },
+    IndentBlanklineContextChar = { fg = c.grey, fmt = "nocombine" },
+    IndentBlanklineContextStart = { sp = c.grey, fmt = "underline" },
+    IndentBlanklineContextSpaceChar = { fmt = "nocombine" },
 }
 
 hl.plugins.mini = {


### PR DESCRIPTION
This commit properly highlights indent blankline plugin highlights using the correct internal api using `fmt` instead of `gui`. This commit also removes an unused highlight. Currently the current context is not highlighted or underlined at all due to the bug in the format of the lua table. This fixes that issue. Thanks