### PR TITLE
Add support for rainbow-delimiters.nvim

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -530,6 +530,16 @@ hl.plugins.ts_rainbow2 = {
     TSRainbowCyan = colors.Cyan,
 }
 
+hl.plugins.rainbow_delimiters = {
+    RainbowDelimiterRed = colors.Red,
+    RainbowDelimiterYellow = colors.Yellow,
+    RainbowDelimiterBlue = colors.Blue,
+    RainbowDelimiterOrange = colors.Orange,
+    RainbowDelimiterGreen = colors.Green,
+    RainbowDelimiterViolet = colors.Purple,
+    RainbowDelimiterCyan = colors.Cyan,
+}
+
 hl.plugins.indent_blankline = {
     IndentBlanklineIndent1 = colors.Blue,
     IndentBlanklineIndent2 = colors.Green,


### PR DESCRIPTION
Add support for [HiPhish/rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim) which is the successor to the now-deprecated [HiPhish/nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)