### PR TITLE
Share we add link option for custom highlight?

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -785,11 +785,15 @@ function M.setup()
     end
 
     for group_name, group_settings in pairs(vim.g.onedark_config.highlights) do
-        vim.api.nvim_command(string.format("highlight %s %s %s %s %s", group_name,
-            replace_color("guifg", group_settings.fg),
-            replace_color("guibg", group_settings.bg),
-            replace_color("guisp", group_settings.sp),
-            replace_color("gui", group_settings.fmt)))
+        if group_settings.link == nil then
+            vim.api.nvim_command(string.format("highlight %s %s %s %s %s", group_name,
+                replace_color("guifg", group_settings.fg),
+                replace_color("guibg", group_settings.bg),
+                replace_color("guisp", group_settings.sp),
+                replace_color("gui", group_settings.fmt)))
+        else
+            vim.api.nvim_set_hl(0, group_name, { link = group_settings.link })
+        end
     end
 end
 


### PR DESCRIPTION
This PR introduces the ability to link one highlight group to another within the plugin. This feature allows users to easily set up and manage complex highlight configurations.