### PR TITLE
Handle typescript incorrect highlights

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -135,6 +135,7 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
     hl.treesitter = {
         ["@annotation"] = colors.Fg,
         ["@attribute"] = colors.Cyan,
+        ["@attribute.typescript"] = colors.Blue,
         ["@boolean"] = colors.Orange,
         ["@character"] = colors.Orange,
         ["@comment"] = {fg = c.grey, fmt = cfg.code_style.comments},


### PR DESCRIPTION
<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="737" alt="Screenshot 2023-08-02 at 1 05 07 PM" src="https://github.com/navarasu/onedark.nvim/assets/25294487/30b97531-d21f-4538-8076-9f838d6b7b77">

</td>
<td>
<img width="485" alt="Screenshot 2023-08-02 at 1 04 43 PM" src="https://github.com/navarasu/onedark.nvim/assets/25294487/775e57e3-b4d3-447c-ac59-378a74880454">

</td>
</tr>
</tbody>
</table>

Due to the fact that treesitter added new global highlighter it does effects the highliting of decorators.
Ref: https://github.com/nvim-treesitter/nvim-treesitter/pull/5113