### PR TITLE
fix(ibl): add updated IndentBlankline highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ require('lualine').setup {
   + [Neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
   + [Neotest](https://github.com/nvim-neotest/neotest)
   + [Barbecue](https://github.com/utilyre/barbecue.nvim)
+  + [IndentBlankline](https://github.com/lukas-reineke/indent-blankline.nvim)
 
 ## Reference
 * [tokyodark.nvim](https://github.com/tiagovla/tokyodark.nvim)

--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -552,6 +552,11 @@ hl.plugins.indent_blankline = {
     IndentBlanklineContextChar = { fg = c.grey, fmt = "nocombine" },
     IndentBlanklineContextStart = { sp = c.grey, fmt = "underline" },
     IndentBlanklineContextSpaceChar = { fmt = "nocombine" },
+
+    -- Ibl v3
+    IblIndent = { fg = c.bg1, fmt = "nocombine" },
+    IblWhitespace = { fmt = "nocombine" },
+    IblScope = { fmt = "nocombine" },
 }
 
 hl.plugins.mini = {


### PR DESCRIPTION
IndentBlankline v3 now uses different highlight groups. Add the new groups to reflect that.

See: https://github.com/lukas-reineke/indent-blankline.nvim/wiki/Migrate-to-version-3

Also add IndentBlankline to readme as supported plugin