### PR TITLE
Actually fix IndentBlankline v3 highlights.

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -555,8 +555,8 @@ hl.plugins.indent_blankline = {
 
     -- Ibl v3
     IblIndent = { fg = c.bg1, fmt = "nocombine" },
-    IblWhitespace = { fmt = "nocombine" },
-    IblScope = { fmt = "nocombine" },
+    IblWhitespace = { fg = c.grey, fmt = "nocombine" },
+    IblScope = { fg = c.grey, fmt = "nocombine" },
 }
 
 hl.plugins.mini = {


### PR DESCRIPTION
PR #190 was supposed to add support for IBL v3, but actually caused a visual change, because it explictly defined the groups, which caused the IBL fallbacks to be not used, but at the same time didn't specify `fg`, which is what's used by IBL v3.

Preview for this PR (notice the underline color):
Before:
<img width="892" alt="Screenshot 2023-11-22 at 3 20 55 PM" src="https://github.com/navarasu/onedark.nvim/assets/1816385/4d837939-fe63-43bf-a4d1-137e926266a8">

After:
<img width="882" alt="Screenshot 2023-11-22 at 3 22 20 PM" src="https://github.com/navarasu/onedark.nvim/assets/1816385/58ec5dff-575a-4ff2-b5c0-b31874f8b3e8">