### PR TITLE
Replace deprecated VertSplit with WinSeparator

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -83,7 +83,7 @@ hl.common = {
     TabLine = {fg = c.fg, bg = c.bg1},
     TabLineFill = {fg = c.grey, bg = c.bg1},
     TabLineSel =  {fg = c.bg0, bg = c.fg},
-    VertSplit = {fg = c.bg3},
+    WinSeparator = {fg = c.bg3},
     Visual = {bg = c.bg3},
     VisualNOS = {fg = c.none, bg = c.bg2, fmt = "underline"},
     QuickFixLine = {fg = c.blue, fmt = "underline"},


### PR DESCRIPTION
`VertSplit` highlight group was [deprecated and replaced](https://github.com/neovim/neovim/pull/17266) with `WinSeparator` in Neovim 0.7.0. The default colorscheme linked `WinSeparator` to `VertSplit` and Onedark inherited this behavior, so it was okay to only define `VertSplit`. However, a [change of default colorscheme](https://github.com/neovim/neovim/pull/26334) was recently merged in Neovim and broke "legacy" colorschemes in [various ways](https://github.com/neovim/neovim/issues/26378) (see item 3 specifically). As a result, the window separator looks as follows in Onedark on the latest Neovim nightly:

![image](https://github.com/navarasu/onedark.nvim/assets/1241736/fa9c8260-ff97-49ee-8aed-ec1f02df9b39)

This PR fixes that:

![image](https://github.com/navarasu/onedark.nvim/assets/1241736/15e5768c-310e-44b8-9fc9-47f71e541f22)
