### PR TITLE
Make markdown headings distinguishable with treesitter

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -201,7 +201,19 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
         ["@variable.builtin"] = {fg = c.red, fmt = cfg.code_style.variables},
         ["@variable.member"] = colors.Cyan,
         ["@variable.parameter"] = colors.Red,
-        
+        ["@markup.heading.1.markdown"] = {fg = c.red, fmt = "bold"},
+        ["@markup.heading.2.markdown"] = {fg = c.purple, fmt = "bold"},
+        ["@markup.heading.3.markdown"] = {fg = c.orange, fmt = "bold"},
+        ["@markup.heading.4.markdown"] = {fg = c.red, fmt = "bold"},
+        ["@markup.heading.5.markdown"] = {fg = c.purple, fmt = "bold"},
+        ["@markup.heading.6.markdown"] = {fg = c.orange, fmt = "bold"},
+        ["@markup.heading.1.marker.markdown"] = {fg = c.red, fmt = "bold"},
+        ["@markup.heading.2.marker.markdown"] = {fg = c.purple, fmt = "bold"},
+        ["@markup.heading.3.marker.markdown"] = {fg = c.orange, fmt = "bold"},
+        ["@markup.heading.4.marker.markdown"] = {fg = c.red, fmt = "bold"},
+        ["@markup.heading.5.marker.markdown"] = {fg = c.purple, fmt = "bold"},
+        ["@markup.heading.6.marker.markdown"] = {fg = c.orange, fmt = "bold"},
+
         -- Old configuration for nvim-treesiter@0.9.1 and below
         ["@conditional"] = {fg = c.purple, fmt = cfg.code_style.keywords},
         ["@exception"] = colors.Purple,


### PR DESCRIPTION
This pr simply defines the treesitter highlight groups `@markup.heading.*.markdown` and `@markup.heading.*.marker.markdown` to make different levels of markdown headings distinguishable when treesitter is enabled on markdown files.
~~I have also **moved** the treesitter related highlight settings **down** so that I can reference highlight settings in `hl.lang.markdown` to avoid redundant definitions.~~