### PR TITLE
Don't set vim.o.termguicolors = true

### DIFF
--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -16,7 +16,6 @@ end
 function M.colorscheme()
     vim.cmd("hi clear")
     if vim.fn.exists("syntax_on") then vim.cmd("syntax reset") end
-    vim.o.termguicolors = true
     vim.g.colors_name = "onedark"
     if vim.o.background == 'light' then
         M.set_options('style', 'light')


### PR DESCRIPTION
Setting `vim.o.termguicolors = true` in latest nightly causes the background color to change temporarily during loading. By default background is not going to be set temporarily if we use`vim.o.termguicolors = false`. This has been discussed in this issue https://github.com/neovim/neovim/issues/26372 and wasn't really resolved. 

See videos below.
Without termguicolors:

https://github.com/navarasu/onedark.nvim/assets/14967831/b4ce1ff2-4ff0-4eb2-a15f-ac7c4280831b

With termguicolors:

https://github.com/navarasu/onedark.nvim/assets/14967831/b0807aa6-e1e0-4599-9671-6481f8556c3b

By not setting `termguicolors = true` we comply with the current requirements for neovim for consistent background. If the user needs the `termguicolors = true` they can always set it in their config. I am not sure why this setting was needed in this plugin in the first place, though. Please let me know if I am missing something.