### PR TITLE
feat: add customization of colors per theme

### DIFF
--- a/lua/onedark/colors.lua
+++ b/lua/onedark/colors.lua
@@ -1,6 +1,8 @@
 local colors = require("onedark.palette")
 
 local function select_colors()
+	colors = vim.tbl_deep_extend("force", colors, vim.g.onedark_config.theme_colors)
+
 	local selected = { none = "none" }
 	selected = vim.tbl_extend("force", selected, colors[vim.g.onedark_config.style])
 	selected = vim.tbl_extend("force", selected, vim.g.onedark_config.colors)

--- a/lua/onedark/init.lua
+++ b/lua/onedark/init.lua
@@ -68,6 +68,7 @@ local default_config = {
     -- Custom Highlights --
     colors = {}, -- Override default colors
     highlights = {}, -- Override highlight groups
+    theme_colors = {}, -- Override colors per-theme
 
     -- Plugins Related --
     diagnostics = {


### PR DESCRIPTION
This allows to override the colors on a per-theme basis, which is useful for specifying background color for example