### PR TITLE
fix: `MiniStatuslineInactive` background color

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -721,7 +721,7 @@ hl.plugins.mini = {
     MiniStatuslineDevinfo = { fg = c.fg, bg = c.bg2 },
     MiniStatuslineFileinfo = { fg = c.fg, bg = c.bg2 },
     MiniStatuslineFilename = { fg = c.grey, bg = c.bg1 },
-    MiniStatuslineInactive = { fg = c.grey, bg = c.bg0 },
+    MiniStatuslineInactive = hl.common.StatusLineNC,
     MiniStatuslineModeCommand = { fg = c.bg0, bg = c.yellow, fmt = "bold" },
     MiniStatuslineModeInsert = { fg = c.bg0, bg = c.blue, fmt = "bold" },
     MiniStatuslineModeNormal = { fg = c.bg0, bg = c.green, fmt = "bold" },


### PR DESCRIPTION
Now tracks `StatusLineNC`. Currently, it's hard to see splits because the inactive statusline background matches the background `Normal`.