### PR TITLE
Remove `@nospell` and `@spell` highlight group definitions

### DIFF
--- a/lua/onedark/highlights.lua
+++ b/lua/onedark/highlights.lua
@@ -241,8 +241,6 @@ if vim.api.nvim_call_function("has", { "nvim-0.8" }) == 1 then
         -- Misc
         ["@none"] = colors.Fg,
         ["@conceal"] = colors.Grey,
-        ["@nospell"] = colors.Fg,
-        ["@spell"] = colors.Fg,
 
         -- Operators
         ["@operator"] = colors.Fg,


### PR DESCRIPTION
Closes #252 

Also fixes #251 